### PR TITLE
updatelogic

### DIFF
--- a/src/main/java/com/lostcatbox/trackingpost/service/PostManager.java
+++ b/src/main/java/com/lostcatbox/trackingpost/service/PostManager.java
@@ -3,37 +3,48 @@ package com.lostcatbox.trackingpost.service;
 import com.lostcatbox.trackingpost.domain.PostDto;
 import com.lostcatbox.trackingpost.service.provider.CJPostProvider;
 import com.lostcatbox.trackingpost.service.provider.CUPostProvider;
+import com.lostcatbox.trackingpost.service.provider.PostProvider;
+import lombok.NoArgsConstructor;
+import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 
 @Service
 public class PostManager {
+
+    private final List<PostProvider> providerList;
     @Autowired
-    CUPostProvider cuPostProvider;
-    @Autowired
-    CJPostProvider cjPostProvider;
+    public PostManager(List<PostProvider> providerList) { // bean에서 해당 타입으로 등록된 빈 list로 주입
+        this.providerList = providerList;
+    }
 
     public PostDto getpost(){
         Map<String, Object> info = getinfo();
-        if (cuPostProvider.isSupport((PostCompanyEnum) info.get("postCompany"))){
-            PostDto result = cuPostProvider.get((String) info.get("postNumber"));
-            result.setKakaoId((String) info.get("kakaoId"));
-            return result;
-        }else if(cjPostProvider.isSupport((PostCompanyEnum) info.get("postCompany"))){
-            PostDto result = cjPostProvider.get((String) info.get("postNumber"));
-            result.setKakaoId((String) info.get("kakaoId"));
-            return result;
-        }else{
-            return null; //null 임시 처리
-        }
+        for (PostProvider provider:providerList){
+            if (!provider.isSupport((PostCompanyEnum) info.get("postCompany"))) { //support확인후 아니면패스
+                continue;
+            }
+            else{
+                PostDto result = provider.get((String) info.get("postNumber"));
+                if (result!=null){ //result 네트워크 오류시 null반환함
+                    result.setKakaoId((String) info.get("kakaoId"));
+                    return result;
+                }
+                else{
+                    return new PostDto(); //null대신 에러를 대체할만한 객체필요
+                }
+            }
+        } //for 문을 다돌아도없다?
+        return new PostDto(); //null대신 에러를 대체할만한 객체필요
     }
     public Map<String,Object> getinfo(){ //test, 추후 요청에 대해 분석해주는 Service 만들거나, controller get인자로 받을에정
         HashMap<String , Object> postInfoMap = new HashMap<>();
-        postInfoMap.put("postCompany", PostCompanyEnum.CU);
-        postInfoMap.put("postNumber", "364321267646");
+        postInfoMap.put("postCompany", PostCompanyEnum.CJ);
+        postInfoMap.put("postNumber", "364321198184");
         postInfoMap.put("kakaoId", "test2802");
         return postInfoMap;
     }


### PR DESCRIPTION
## 조회 빈이 2개이상일때 문제

### 문제점

provider의 인터페이스의 구현체인 택배 크롤링 provider들은 ProviderManager 에서 각자 주입되어야했다. 하지만 이는 DI의 원칙을 위배한것이므로 다음과 같이 해결했다

### 해결

- List<DiscountPolicy> 해당 타입의 모든 스프링빈 반환 특징을 이용하여 주입하였다.

```java
@Service
public class PostManager {

    private final List<PostProvider> providerList;
    @Autowired
    public PostManager(List<PostProvider> providerList) { // bean에서 해당 타입으로 등록된 빈 list로 주입
        this.providerList = providerList;
    }
...
}
```

### 추가 정보

- **@Autowired를 하면 스프링 빈에 타입을 조회로 하여 주입된다.** 따라서, 같은 타입이 두개라면 문제가 발생한다.
- 해결책은 많다.
    - @Autowired 필드 명 매칭
    - @Qualifier @Qualifier끼리 매칭 빈 이름 매칭
    - @Primary 사용
    - Map<String, DiscountPolicy> 해당 타입의 모든 스프링 빈과 해당 값 반환 → 없다면 빈 List반환
    - **List<DiscountPolicy> 해당 타입의 모든 스프링빈 반환 →없다면 빈 List반환**