### PR TITLE
PostEntityAdd_PostCompanyEnum

### DIFF
--- a/externalpost/src/main/java/com/example/externalpost/service/PostManager.java
+++ b/externalpost/src/main/java/com/example/externalpost/service/PostManager.java
@@ -26,6 +26,7 @@ public class PostManager {
                 PostDto result = provider.get(requestInfo.getPostNumber());
                 if (result!=null){ //result 네트워크 오류시 null반환함
                     result.setKakaoId(requestInfo.getRequestUser());
+                    result.setPostCompany(requestInfo.getPostCompany());
                     return result;
                 }
                 else{

--- a/frontend/src/views/posts/PostDetails.vue
+++ b/frontend/src/views/posts/PostDetails.vue
@@ -70,10 +70,14 @@ export default {
     })
   },
   fnUpdate(){
-    this.postCompany ="CJ대한통운",
+    this.postCompany ="CJ대한통운" //실서비스에선 필요없음
     this.$axios.post(
         this.$homeserviceAPIUrl + "/"+this.$route.params.userId+"/"+this.$route.params.postNumber+"/",
-        {},{params: {"postCompany":this.postCompany}}
+        {},{
+          params: {"postCompany":this.postCompany},
+          headers: {  'Content-type': 'application/x-www-form-urlencoded; charset=UTF-8',
+            'Accept': '*/*'}
+        }
     ).then(()=> {
       alert("새로고침되었습니다.")
     }).catch((err)=> {

--- a/servicehome/src/main/java/com/lostcatbox/trackingpost/controller/PostController.java
+++ b/servicehome/src/main/java/com/lostcatbox/trackingpost/controller/PostController.java
@@ -3,6 +3,7 @@ package com.lostcatbox.trackingpost.controller;
 import com.example.trackingpostcore.domain.PostCompanyEnum;
 import com.example.trackingpostcore.domain.PostDto;
 import com.example.trackingpostcore.domain.RequestInfo;
+import com.lostcatbox.trackingpost.domain.ResponsePost;
 import com.lostcatbox.trackingpost.service.PostDbService;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
@@ -29,13 +30,13 @@ public class PostController {
     // id값은 DB아이디 값이며, kakaoid값으로 추후 바뀔수있다. 하지만 현재로는 이렇게 검증하고, 가장 최근 자료를 보여주는것이 좋은듯
     //카카오 임시로 일단 String 반환하게해놓음
     @GetMapping ("/{userId}/{postNumber}/")
-    public PostDto getpost(@PathVariable String userId,@PathVariable String postNumber){
+    public ResponsePost getpost(@PathVariable String userId,@PathVariable String postNumber){
         PostDto recentPost = postDbService.getRecentPost(userId, postNumber);//인자 &조건으로 가장최근 데이터 반환, 없다면 null
         if (ObjectUtils.isEmpty(recentPost)){ //Object의 null값을 체크한다!
-            return new PostDto();
+            return new ResponsePost();
         }
         else{
-            return recentPost;
+            return new ResponsePost(recentPost);
         }
     }
      //내 서버로 응답한 link경로로 접근한후 post로 새로고침 명령시 -> kafka로 외부 택배 조회 메세지 보내기 pub
@@ -54,13 +55,21 @@ public class PostController {
     }
     //해당유저의 모든 택배조회 기록 반환
     @GetMapping("/{userId}/")
-    public List<PostDto> getpostlist(@PathVariable String userId){
+    public List<ResponsePost> getpostlist(@PathVariable String userId){
         List<PostDto> postList = postDbService.getPostList(userId);
         if (ObjectUtils.isEmpty(postList)){ //Object의 null값을 체크한다!
             return new ArrayList<>();
         }
         else{
-            return postList;
+            return convert(postList);
         }
+    }
+    private List<ResponsePost> convert(List<PostDto> postList) {
+        List<ResponsePost> responsePostList=new ArrayList<>();
+        for (PostDto postdto: postList){
+            ResponsePost responsePost = new ResponsePost(postdto);
+            responsePostList.add(responsePost);
+        }
+        return responsePostList;
     }
 }

--- a/servicehome/src/main/java/com/lostcatbox/trackingpost/domain/ResponsePost.java
+++ b/servicehome/src/main/java/com/lostcatbox/trackingpost/domain/ResponsePost.java
@@ -1,0 +1,41 @@
+package com.lostcatbox.trackingpost.domain;
+
+import com.example.trackingpostcore.domain.Post;
+import com.example.trackingpostcore.domain.PostCompanyEnum;
+import com.example.trackingpostcore.domain.PostDto;
+import lombok.*;
+
+import java.time.LocalDateTime;
+@Getter
+@Setter
+@NoArgsConstructor
+@ToString
+public class ResponsePost {
+    private String kakaoId; //kakao id
+    private String postCompany; //택배회사
+    private String postNumber; //송장번호
+    private String sender; //보내는이
+    private String receiver; //받는이
+    private String contentType; //내용물 타입
+    private String message; // detail한 메세지
+    private String location; // 위치(허브->허브 or담당지)
+    private String statusData; //택배사의 기록 업데이트 날짜
+    private String status; // 간선상차, 하차 등등
+    private LocalDateTime createdDate; // 처음 만들어진 날짜
+    private LocalDateTime modifiedDate; //최근 정보 업데이트 날짜
+
+    public ResponsePost(PostDto postDto) { //post모든 정보 get
+        this.kakaoId = postDto.getKakaoId();
+        this.postCompany = postDto.getPostCompany().getName();
+        this.postNumber = postDto.getPostNumber();
+        this.sender = postDto.getSender();
+        this.receiver = postDto.getReceiver();
+        this.contentType = postDto.getContentType();
+        this.message = postDto.getMessage();
+        this.location = postDto.getLocation();
+        this.statusData = postDto.getStatusData();
+        this.status = postDto.getStatus();
+        this.createdDate = postDto.getCreatedDate();
+        this.modifiedDate = postDto.getModifiedDate();
+    }
+}

--- a/trackingpost-core/src/main/java/com/example/trackingpostcore/domain/KindRequest.java
+++ b/trackingpost-core/src/main/java/com/example/trackingpostcore/domain/KindRequest.java
@@ -1,5 +1,0 @@
-package com.example.trackingpostcore.domain;
-
-public enum KindRequest {
-    Kakao,Web
-}

--- a/trackingpost-core/src/main/java/com/example/trackingpostcore/domain/Post.java
+++ b/trackingpost-core/src/main/java/com/example/trackingpostcore/domain/Post.java
@@ -21,6 +21,9 @@ public class Post {
     private Long id; //unique id
     @Column(length=50,nullable =false)
     private String kakaoId; //kakao id
+    @Enumerated(EnumType.STRING)
+    @Column(length=50,nullable =false)
+    private PostCompanyEnum postCompany; //postCompany
     @Column(length=50,nullable =false)
     private String postNumber; //송장번호
     @Column(length=20,nullable =false)
@@ -46,9 +49,10 @@ public class Post {
     private LocalDateTime modifiedDate; //최근 정보 업데이트 날짜
 
     @Builder
-    public Post(Long id, String kakaoId, String postNumber, String sender, String receiver, String contentType, String message, String location, String statusData, String status) {
+    public Post(Long id, String kakaoId,PostCompanyEnum postCompanyEnum, String postNumber, String sender, String receiver, String contentType, String message, String location, String statusData, String status) {
         this.id = id;
         this.kakaoId = kakaoId;
+        this.postCompany = postCompanyEnum;
         this.postNumber = postNumber;
         this.sender = sender;
         this.receiver = receiver;

--- a/trackingpost-core/src/main/java/com/example/trackingpostcore/domain/PostCompanyEnum.java
+++ b/trackingpost-core/src/main/java/com/example/trackingpostcore/domain/PostCompanyEnum.java
@@ -23,6 +23,6 @@ public enum PostCompanyEnum {
         return Arrays.stream(values())
                 .filter(value -> value.name.equals(name))
                 .findAny()
-                .orElse(null);
+                .orElseThrow(()-> new RuntimeException("해당하는enum값없음"));
     }
 }

--- a/trackingpost-core/src/main/java/com/example/trackingpostcore/domain/PostDto.java
+++ b/trackingpost-core/src/main/java/com/example/trackingpostcore/domain/PostDto.java
@@ -11,6 +11,7 @@ import java.time.LocalDateTime;
 public class PostDto {
     private Long id; //unique id
     private String kakaoId; //kakao id
+    private PostCompanyEnum postCompany; //택배회사
     private String postNumber; //송장번호
     private String sender; //보내는이
     private String receiver; //받는이
@@ -28,6 +29,7 @@ public class PostDto {
         Post post = Post.builder()
                 .id(id)
                 .kakaoId(kakaoId)
+                .postCompanyEnum(postCompany)
                 .postNumber(postNumber)
                 .sender(sender)
                 .receiver(receiver)
@@ -40,9 +42,10 @@ public class PostDto {
         return post;
     }
     @Builder     //id 까지 builder에 포함해야하나? 근데 수정할때도 post로 가져와서 update()함수 만들어놓으면 필요없긴한데?
-    public PostDto(Long id, String kakaoId, String postNumber, String sender, String receiver, String contentType, String message, String location, String statusData, String status) {
+    public PostDto(Long id, String kakaoId,PostCompanyEnum postCompanyEnum, String postNumber, String sender, String receiver, String contentType, String message, String location, String statusData, String status) {
         this.id = id;
         this.kakaoId = kakaoId;
+        this.postCompany = postCompanyEnum;
         this.postNumber = postNumber;
         this.sender = sender;
         this.receiver = receiver;
@@ -56,6 +59,7 @@ public class PostDto {
     public PostDto(Post post) { //post모든 정보 get
         this.id = post.getId();
         this.kakaoId = post.getKakaoId();
+        this.postCompany = post.getPostCompany();
         this.postNumber = post.getPostNumber();
         this.sender = post.getSender();
         this.receiver = post.getReceiver();

--- a/trackingpost-core/src/main/java/com/example/trackingpostcore/domain/RequestInfo.java
+++ b/trackingpost-core/src/main/java/com/example/trackingpostcore/domain/RequestInfo.java
@@ -1,6 +1,5 @@
 package com.example.trackingpostcore.domain;
 
-import com.example.trackingpostcore.domain.KindRequest;
 import com.example.trackingpostcore.domain.PostCompanyEnum;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -12,7 +11,6 @@ import lombok.ToString;
 @ToString
 @NoArgsConstructor
 public class RequestInfo {
-    private KindRequest kindRequest;
     private String postNumber;
     private String requestUser;
     private PostCompanyEnum postCompany;


### PR DESCRIPTION
postCompeny를 ENUM으로 처리함에 따라 DB나 다른 DTO에서의 처리를 정의할 필요가있었다.

jpa의 postCompony Enum 처리

string으로 DB에도 남기고싶기에 다음과같이 처리하였다.

- post entitiy에 추가

```java
@Enumerated(EnumType.STRING)
    @Column(length=50,nullable =false)
    private PostCompanyEnum postCompany; //postCompany
```

위 정보에 맞게 dto들도 수정하였다.

추가로 response용 dto를 따로 만들어 응답하므로 내부 id값등의 불필요한 정보는 유저에게 주지않았다. 또한 postConpany 값마다의 name을 정해 name으로 반환하도록하였다