### PR TITLE
Feature/add aop

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -15,15 +15,19 @@ allprojects{
 	}
 }
 
-configurations {
-	compileOnly {
-		extendsFrom annotationProcessor
-	}
-}
 subprojects {
 	apply plugin: 'java'
 	apply plugin: 'org.springframework.boot'
 	apply plugin: 'io.spring.dependency-management'
+
+	configurations {
+		asciidoctorExtensions
+
+		compileOnly {
+			extendsFrom annotationProcessor
+		}
+	}
+
 
 	dependencies {
 		implementation 'org.springframework.boot:spring-boot-starter-security'
@@ -39,6 +43,10 @@ subprojects {
 		runtimeOnly 'mysql:mysql-connector-java'
 		//kafka설치
 		implementation 'org.springframework.kafka:spring-kafka'
+		//aop
+		implementation 'org.springframework.boot:spring-boot-starter-aop'
+		implementation("com.google.guava:guava:24.0-jre") // aop에서 Joiner사용목적
+
 	}
 
 	tasks.named('test') {

--- a/externalpost/src/main/java/com/example/externalpost/service/PostDbService.java
+++ b/externalpost/src/main/java/com/example/externalpost/service/PostDbService.java
@@ -24,11 +24,11 @@ public class PostDbService {
         Post recentPost = postRepository.findTopByPostNumberAndKakaoIdOrderByModifiedDateDesc(postDto.getPostNumber(), postDto.getKakaoId()).orElse(Post.getDefaultErrorPost());
         if (recentPost.getStatusData().equals(postDto.getStatusData())) {
             recentPost.update(LocalDateTime.now()); //spring에서 한 트랜젝션에서의 변경은 더티체킹일어남
-            log.info("해당 택배 상태는 이미 최신 것: "+postDto);
+            log.info("해당 택배 상태는 이미 최신 것: "+postDto.toString());
             return postDto;
         }
         postRepository.save(postDto.toEntity());
-        log.info("해당 택배를 새로이 업데이트함: "+postDto);
+        log.info("해당 택배를 새로이 업데이트함: "+postDto.toString());
         return postDto;
     }
 }

--- a/kakaochannel/src/main/java/com/example/kakaochannel/KakaochannelApplication.java
+++ b/kakaochannel/src/main/java/com/example/kakaochannel/KakaochannelApplication.java
@@ -5,9 +5,11 @@ import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.boot.autoconfigure.jdbc.DataSourceAutoConfiguration;
 import org.springframework.boot.autoconfigure.security.servlet.SecurityAutoConfiguration;
+import org.springframework.context.annotation.EnableAspectJAutoProxy;
 
 @EnableAutoConfiguration(exclude = DataSourceAutoConfiguration.class) //데이터소스 무시
 @SpringBootApplication
+@EnableAspectJAutoProxy
 public class KakaochannelApplication {
 
     public static void main(String[] args) {

--- a/kakaochannel/src/main/java/com/example/kakaochannel/config/ServiceConfig.java
+++ b/kakaochannel/src/main/java/com/example/kakaochannel/config/ServiceConfig.java
@@ -1,0 +1,11 @@
+package com.example.kakaochannel.config;
+
+import com.example.trackingpostcore.aop.LogConfig;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.ComponentScan;
+import org.springframework.context.annotation.Configuration;
+
+@ComponentScan("com.example.trackingpostcore.aop") //aop LogConfig 현재 module실행시 Bean에 등록
+@Configuration
+public class ServiceConfig {
+}

--- a/kakaochannel/src/main/java/com/example/kakaochannel/config/SpringSecurityConfig.java
+++ b/kakaochannel/src/main/java/com/example/kakaochannel/config/SpringSecurityConfig.java
@@ -1,5 +1,7 @@
 package com.example.kakaochannel.config;
 
+import com.example.trackingpostcore.aop.LogConfig;
+import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.WebSecurityConfigurerAdapter;

--- a/kakaochannel/src/main/java/com/example/kakaochannel/controller/KakaoController.java
+++ b/kakaochannel/src/main/java/com/example/kakaochannel/controller/KakaoController.java
@@ -2,6 +2,7 @@ package com.example.kakaochannel.controller;
 
 import com.example.kakaochannel.domain.KakaoLinkResponse;
 import com.example.kakaochannel.service.ResponseService;
+import com.example.trackingpostcore.aop.Logging;
 import com.example.trackingpostcore.domain.RequestInfo;
 import com.example.kakaochannel.service.ValidRequest;
 import com.google.gson.JsonObject;

--- a/kakaochannel/src/main/java/com/example/kakaochannel/controller/KakaoController.java
+++ b/kakaochannel/src/main/java/com/example/kakaochannel/controller/KakaoController.java
@@ -27,6 +27,7 @@ public class KakaoController {
     private static final String topicName = "posttopic";
 
     @PostMapping(value = "/")
+    @Logging
     public String gethomepage(@RequestBody String params) {
         RequestInfo requestInfo = validRequest.getinfo(params); // 요청에 대한 정보 추출
         String result = responseService.getFailResponse(); ////반드시 카카오엔 응답해야하는상황.서비스로빼고, advice에도 Exception후 return 으로 getFailResponse해도되는지

--- a/servicehome/src/main/java/com/lostcatbox/trackingpost/ServicehomeApplication.java
+++ b/servicehome/src/main/java/com/lostcatbox/trackingpost/ServicehomeApplication.java
@@ -3,6 +3,7 @@ package com.lostcatbox.trackingpost;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.boot.autoconfigure.domain.EntityScan;
+import org.springframework.context.annotation.EnableAspectJAutoProxy;
 import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 import org.springframework.data.jpa.repository.config.EnableJpaRepositories;
 
@@ -10,6 +11,7 @@ import org.springframework.data.jpa.repository.config.EnableJpaRepositories;
 @EnableJpaAuditing
 @EnableJpaRepositories(basePackages = {"com.example.trackingpostcore"}) //com.example.trackingpostcore 하위에 있는 jpaRepository를 상속한 repository scan
 @EntityScan(basePackages = {"com.example.trackingpostcore"}) //com.example.trackingpostcore 하위에 있는 @Entity 클래스 scan
+@EnableAspectJAutoProxy
 public class ServicehomeApplication {
 
 	public static void main(String[] args) {

--- a/servicehome/src/main/java/com/lostcatbox/trackingpost/config/ServiceConfig.java
+++ b/servicehome/src/main/java/com/lostcatbox/trackingpost/config/ServiceConfig.java
@@ -1,0 +1,9 @@
+package com.lostcatbox.trackingpost.config;
+
+import org.springframework.context.annotation.ComponentScan;
+import org.springframework.context.annotation.Configuration;
+
+@ComponentScan("com.example.trackingpostcore.aop") //aop LogConfig 현재 module실행시 Bean에 등록
+@Configuration
+public class ServiceConfig {
+}

--- a/servicehome/src/main/java/com/lostcatbox/trackingpost/controller/PostController.java
+++ b/servicehome/src/main/java/com/lostcatbox/trackingpost/controller/PostController.java
@@ -1,5 +1,6 @@
 package com.lostcatbox.trackingpost.controller;
 
+import com.example.trackingpostcore.aop.Logging;
 import com.example.trackingpostcore.domain.PostCompanyEnum;
 import com.example.trackingpostcore.domain.PostDto;
 import com.example.trackingpostcore.domain.RequestInfo;
@@ -27,12 +28,14 @@ public class PostController {
     // 내 서버가 응답한 link경로로 접근한경우
     // id값은 DB아이디 값이며, kakaoid값으로 추후 바뀔수있다. 하지만 현재로는 이렇게 검증하고, 가장 최근 자료를 보여주는것이 좋은듯
     @GetMapping ("/{userId}/{postNumber}/")
+    @Logging
     public ResponsePost getpost(@PathVariable String userId,@PathVariable String postNumber){
         PostDto recentPost = postDbService.getRecentPost(userId, postNumber);//인자 &조건으로 가장최근 데이터 반환, 없다면 null
         return new ResponsePost(recentPost);
     }
      //내 서버로 응답한 link경로로 접근한후 post로 새로고침 명령시 -> kafka로 외부 택배 조회 메세지 보내기 pub
     @PostMapping("/{userId}/{postNumber}/")
+    @Logging
     public HttpStatus requestRefresh(@PathVariable String userId, @PathVariable String postNumber, @RequestParam String postCompany){
         PostCompanyEnum postCompanyEnum = PostCompanyEnum.valueOfName(postCompany).orElseThrow(()-> new NotFoundCompanyEnumCException("servicehome 새로고침시 해당하는 택배사조회 못함"));
         RequestInfo requestInfo = new RequestInfo(postNumber,userId, postCompanyEnum);
@@ -41,6 +44,7 @@ public class PostController {
     }
     //해당유저의 모든 택배조회 기록 반환
     @GetMapping("/{userId}/")
+    @Logging
     public List<ResponsePost> getpostlist(@PathVariable String userId){
         List<PostDto> postList = postDbService.getPostList(userId);
         return convert(postList);

--- a/servicehome/src/main/java/com/lostcatbox/trackingpost/service/PostDbService.java
+++ b/servicehome/src/main/java/com/lostcatbox/trackingpost/service/PostDbService.java
@@ -22,8 +22,8 @@ public class PostDbService {
 
     //송장번호중 가장 최근 post정보 가져옴
     public PostDto getRecentPost(String kakaoId, String postNumber){
-        Post recentPost = postRepository.findTopByPostNumberAndKakaoIdOrderByModifiedDateDesc(postNumber,kakaoId).orElseThrow(
-                ()-> new NotFoundPostCException("RecentPost호출시 해당정보로된 Post 없음"));
+        Post recentPost = postRepository.findTopByPostNumberAndKakaoIdOrderByModifiedDateDesc(postNumber,kakaoId)
+                .orElseThrow(()-> new NotFoundPostCException("RecentPost호출시 해당정보로된 Post 없음"));
         return new PostDto(recentPost);
     }
     public List<PostDto> getPostList(String kakaoId){

--- a/trackingpost-core/src/main/java/com/example/trackingpostcore/aop/LogConfig.java
+++ b/trackingpost-core/src/main/java/com/example/trackingpostcore/aop/LogConfig.java
@@ -1,0 +1,68 @@
+package com.example.trackingpostcore.aop;
+
+import com.google.common.base.Joiner;
+import lombok.extern.slf4j.Slf4j;
+import org.aspectj.lang.ProceedingJoinPoint;
+import org.aspectj.lang.annotation.Around;
+import org.aspectj.lang.annotation.Aspect;
+import org.springframework.stereotype.Component;
+import org.springframework.web.context.request.RequestAttributes;
+import org.springframework.web.context.request.RequestContextHolder;
+import org.springframework.web.context.request.ServletRequestAttributes;
+
+import javax.servlet.http.HttpServletRequest;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+@Slf4j
+@Component
+@Aspect
+public class LogConfig {
+    //around이므로 메서드 실행 전, 후 시점에 메서드 실행함. 본 메서드 실행은 pjp.proceed()
+    ////within으로 범위설정가능
+    @Around("@annotation(Logging)")
+    public Object logging(ProceedingJoinPoint pjp) throws Throwable {
+        String params = getRequestParams(); //request값 가져오기
+
+        long startAt = System.currentTimeMillis();
+        log.info("-----------> REQUEST : {}({}) = {}", pjp.getSignature().getDeclaringTypeName(),
+                pjp.getSignature().getName(), params);
+
+        Object result = pjp.proceed(); // 본 메서드 실행
+
+        long endAt = System.currentTimeMillis();
+
+        log.info("-----------> RESPONSE : {}({}) = {} ({}ms)", pjp.getSignature().getDeclaringTypeName(),
+                pjp.getSignature().getName(), result, endAt - startAt);
+
+        return result;
+    }
+
+    // Get request values
+    private String getRequestParams() {
+
+        String params = "없음";
+
+        RequestAttributes requestAttributes = RequestContextHolder
+                .getRequestAttributes(); // 3
+
+        if (requestAttributes != null) {
+            HttpServletRequest request = ((ServletRequestAttributes) RequestContextHolder
+                    .getRequestAttributes()).getRequest();
+
+            Map<String, String[]> paramMap = request.getParameterMap();
+            if (!paramMap.isEmpty()) {
+                params = " [" + paramMapToString(paramMap) + "]";
+            }
+        }
+
+        return params;
+
+    }
+    private String paramMapToString(Map<String, String[]> paramMap) {
+        return paramMap.entrySet().stream()
+                .map(entry -> String.format("%s -> (%s)",
+                        entry.getKey(), Joiner.on(",").join(entry.getValue())))
+                .collect(Collectors.joining(", "));
+    }
+}

--- a/trackingpost-core/src/main/java/com/example/trackingpostcore/aop/Logging.java
+++ b/trackingpost-core/src/main/java/com/example/trackingpostcore/aop/Logging.java
@@ -1,0 +1,11 @@
+package com.example.trackingpostcore.aop;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target({ElementType.METHOD}) // 로그를 제외하는 에너테이션이므로 메서드위에 구현할것
+@Retention(RetentionPolicy.RUNTIME) // 실행동안 유지해야하므로
+public @interface Logging {
+}


### PR DESCRIPTION
## logging개선

- 일일히 모든 로직에 log를 선언하는것은 일관되지않았고,유지보수가 힘들었다.
- 따라서 공통 관심 사항(부가기능)과 핵심 관심 사항(핵심기능)을 다음과 다음과같이 분리하였다.
   
    - AOP를 활용하여 접속 및 응답시 logging(공통 기능)(부가기능)
    - `@ExceptionHandler` 를 통해 CustomException발생시 logging(핵심기능)
    - save등등 민감한 부분의 경우 따로 직접 logging처리(핵심기능)

### AOP

- 이를 통해, 모든 외부 요청에 대해서 처리하는 kakaochannel과 servicehome 모듈에 대해 공통적으로 logging을 할수있었다.
- 요청시 →Request에 관한 정보 logging →비즈니스로직 →Response에관한 정보→ 종료
- @Logging 에너테이션을 기준으로 공통 logging 기능구현을 함에 따라 추후에도 추가 및 변경에 용이하도록하였다.

```java
public class LogConfig {
    //around이므로 메서드 실행 전, 후 시점에 메서드 실행함. 본 메서드 실행은 pjp.proceed()
    ////within으로 범위설정가능
    @Around("@annotation(Logging)")
    public Object logging(ProceedingJoinPoint pjp) throws Throwable {
        String params = getRequestParams(); //request값 가져오기

        long startAt = System.currentTimeMillis();
        log.info("-----------> REQUEST : {}({}) = {}", pjp.getSignature().getDeclaringTypeName(),
                pjp.getSignature().getName(), params);

        Object result = pjp.proceed(); // 본 메서드 실행

        long endAt = System.currentTimeMillis();

        log.info("-----------> RESPONSE : {}({}) = {} ({}ms)", pjp.getSignature().getDeclaringTypeName(),
                pjp.getSignature().getName(), result, endAt - startAt);

        return result;
    }

    // Get request values
    private String getRequestParams() {

        String params = "없음";

        RequestAttributes requestAttributes = RequestContextHolder
                .getRequestAttributes(); // 3

        if (requestAttributes != null) {
            HttpServletRequest request = ((ServletRequestAttributes) RequestContextHolder
                    .getRequestAttributes()).getRequest();

            Map<String, String[]> paramMap = request.getParameterMap();
            if (!paramMap.isEmpty()) {
                params = " [" + paramMapToString(paramMap) + "]";
            }
        }

        return params;

    }
    private String paramMapToString(Map<String, String[]> paramMap) {
        return paramMap.entrySet().stream()
                .map(entry -> String.format("%s -> (%s)",
                        entry.getKey(), Joiner.on(",").join(entry.getValue())))
                .collect(Collectors.joining(", "));
    }
}
```

### CustomException과 Advice

- CustomException을 통해 다양한 에러에 대해 명확한 정보를 기록할수있도록하였다.
- `@RestControllerAdvice` 로 각각의 CException에 대해 `@ExceptionHandler` 를 활용하여, 해당 에러에 대해 logging을 할수있도록하였다.

### savePost()와 같은 핵심기능의 logging

- 아래와같이 서비스에서의 중요로직에 대해서는 직접 logging을 해주었다.

```java
public PostDto savePost(PostDto postDto) {
        //Optional 반환하는 JPA사용시 Optional를 바로 null 체크하여, 값을 무조건 갖도록한다.(NPE피함+Optional로 책임전가 불가)
        //추후 JPA에서 boolen사용하자
        Post recentPost = postRepository.findTopByPostNumberAndKakaoIdOrderByModifiedDateDesc(postDto.getPostNumber(), postDto.getKakaoId()).orElse(Post.getDefaultErrorPost());
        if (recentPost.getStatusData().equals(postDto.getStatusData())) {
            recentPost.update(LocalDateTime.now()); //spring에서 한 트랜젝션에서의 변경은 더티체킹일어남
            log.info("해당 택배 상태는 이미 최신 것: "+postDto.toString());
            return postDto;
        }
        postRepository.save(postDto.toEntity());
        log.info("해당 택배를 새로이 업데이트함: "+postDto.toString());
        return postDto;
    }
```